### PR TITLE
refactor: migrate type references from Kamaji to Steward

### DIFF
--- a/api/v1alpha1/clusterbootstrap_types.go
+++ b/api/v1alpha1/clusterbootstrap_types.go
@@ -345,7 +345,7 @@ type ClusterBootstrapAddonsSpec struct {
 	// +optional
 	Ingress *IngressAddonSpec `json:"ingress,omitempty"`
 
-	// ControlPlaneProvider defines hosted control plane provider (Kamaji)
+	// ControlPlaneProvider defines hosted control plane provider (Steward)
 	// +optional
 	ControlPlaneProvider *ControlPlaneProviderAddonSpec `json:"controlPlaneProvider,omitempty"`
 
@@ -467,11 +467,11 @@ type IngressAddonSpec struct {
 // ControlPlaneProviderAddonSpec defines hosted control plane provider configuration
 type ControlPlaneProviderAddonSpec struct {
 	// Type is the control plane provider type
-	// +kubebuilder:validation:Enum=kamaji;none
-	// +kubebuilder:default=kamaji
+	// +kubebuilder:validation:Enum=steward;kamaji;none
+	// +kubebuilder:default=steward
 	Type string `json:"type,omitempty"`
 
-	// Enabled controls whether Kamaji is installed
+	// Enabled controls whether Steward is installed
 	// +optional
 	// +kubebuilder:default=true
 	Enabled *bool `json:"enabled,omitempty"`

--- a/api/v1alpha1/tenantcluster_types.go
+++ b/api/v1alpha1/tenantcluster_types.go
@@ -68,7 +68,7 @@ type TenantClusterSpec struct {
 	// +optional
 	ProviderConfigRef *LocalObjectReference `json:"providerConfigRef,omitempty"`
 
-	// ControlPlane configures the Kamaji-hosted control plane.
+	// ControlPlane configures the Steward-hosted control plane.
 	// +optional
 	ControlPlane ControlPlaneSpec `json:"controlPlane,omitempty"`
 
@@ -96,17 +96,17 @@ type TenantClusterSpec struct {
 	InfrastructureOverride *InfrastructureOverride `json:"infrastructureOverride,omitempty"`
 }
 
-// ControlPlaneSpec configures the Kamaji-hosted control plane.
+// ControlPlaneSpec configures the Steward-hosted control plane.
 type ControlPlaneSpec struct {
 	// Replicas is the number of API server replicas.
-	// Kamaji manages high availability automatically.
+	// Steward manages high availability automatically.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=3
 	// +optional
 	Replicas int32 `json:"replicas,omitempty"`
 
-	// DataStoreRef references the Kamaji DataStore to use.
+	// DataStoreRef references the Steward DataStore to use.
 	// If not specified, the default DataStore is used.
 	// +optional
 	DataStoreRef *LocalObjectReference `json:"dataStoreRef,omitempty"`
@@ -479,7 +479,7 @@ type TenantClusterStatus struct {
 	// +optional
 	Phase TenantClusterPhase `json:"phase,omitempty"`
 
-	// TenantNamespace is the namespace containing CAPI/Kamaji resources.
+	// TenantNamespace is the namespace containing CAPI/Steward resources.
 	// +optional
 	TenantNamespace string `json:"tenantNamespace,omitempty"`
 

--- a/config/crd/bases/butler.butlerlabs.dev_clusterbootstraps.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_clusterbootstraps.yaml
@@ -220,16 +220,17 @@ spec:
                     type: object
                   controlPlaneProvider:
                     description: ControlPlaneProvider defines hosted control plane
-                      provider (Kamaji)
+                      provider (Steward)
                     properties:
                       enabled:
                         default: true
-                        description: Enabled controls whether Kamaji is installed
+                        description: Enabled controls whether Steward is installed
                         type: boolean
                       type:
-                        default: kamaji
+                        default: steward
                         description: Type is the control plane provider type
                         enum:
+                        - steward
                         - kamaji
                         - none
                         type: string

--- a/config/crd/bases/butler.butlerlabs.dev_tenantclusters.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_tenantclusters.yaml
@@ -207,7 +207,7 @@ spec:
                     type: object
                 type: object
               controlPlane:
-                description: ControlPlane configures the Kamaji-hosted control plane.
+                description: ControlPlane configures the Steward-hosted control plane.
                 properties:
                   certSANs:
                     description: |-
@@ -218,7 +218,7 @@ spec:
                     type: array
                   dataStoreRef:
                     description: |-
-                      DataStoreRef references the Kamaji DataStore to use.
+                      DataStoreRef references the Steward DataStore to use.
                       If not specified, the default DataStore is used.
                     properties:
                       name:
@@ -238,7 +238,7 @@ spec:
                     default: 1
                     description: |-
                       Replicas is the number of API server replicas.
-                      Kamaji manages high availability automatically.
+                      Steward manages high availability automatically.
                     format: int32
                     maximum: 3
                     minimum: 1
@@ -590,7 +590,7 @@ spec:
                 - Failed
                 type: string
               tenantNamespace:
-                description: TenantNamespace is the namespace containing CAPI/Kamaji
+                description: TenantNamespace is the namespace containing CAPI/Steward
                   resources.
                 type: string
               workerNodesDesired:


### PR DESCRIPTION
- Update comments in TenantCluster types
- Update comments in ClusterBootstrap types
- Change control plane enum default: kamaji → steward
- Keep kamaji in enum for backward compatibility
- Regenerate CRD manifests