### PR TITLE
Remove default from TenantCluster.controlPlane.serviceType

### DIFF
--- a/api/v1alpha1/tenantcluster_types.go
+++ b/api/v1alpha1/tenantcluster_types.go
@@ -112,8 +112,9 @@ type ControlPlaneSpec struct {
 	DataStoreRef *LocalObjectReference `json:"dataStoreRef,omitempty"`
 
 	// ServiceType for the control plane endpoint.
+	// If not specified, inherits from ButlerConfig.spec.controlPlaneExposure.mode.
+	// Only set this to override the platform-level setting for this specific cluster.
 	// +kubebuilder:validation:Enum=LoadBalancer;NodePort;ClusterIP
-	// +kubebuilder:default="LoadBalancer"
 	// +optional
 	ServiceType string `json:"serviceType,omitempty"`
 

--- a/config/crd/bases/butler.butlerlabs.dev_tenantclusters.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_tenantclusters.yaml
@@ -244,8 +244,10 @@ spec:
                     minimum: 1
                     type: integer
                   serviceType:
-                    default: LoadBalancer
-                    description: ServiceType for the control plane endpoint.
+                    description: |-
+                      ServiceType for the control plane endpoint.
+                      If not specified, inherits from ButlerConfig.spec.controlPlaneExposure.mode.
+                      Only set this to override the platform-level setting for this specific cluster.
                     enum:
                     - LoadBalancer
                     - NodePort


### PR DESCRIPTION
## Summary
Remove the CRD default for `controlPlane.serviceType` so TenantClusters inherit from platform-level ControlPlaneExposure mode.

## Problem
The `+kubebuilder:default="LoadBalancer"` marker was overriding `ButlerConfig.spec.controlPlaneExposure.mode`, preventing Ingress/Gateway modes from working correctly.

## Fix
- Remove `+kubebuilder:default="LoadBalancer"` from serviceType field
- Update description to document inheritance behavior