### PR TITLE
feat: add controllerType to ControlPlaneExposureSpec

### DIFF
--- a/api/v1alpha1/butlerconfig_types.go
+++ b/api/v1alpha1/butlerconfig_types.go
@@ -261,3 +261,11 @@ func (c *ButlerConfig) GetControlPlaneExposureIngressClassName() string {
 	}
 	return c.Spec.ControlPlaneExposure.IngressClassName
 }
+
+// GetControlPlaneExposureControllerType returns the ingress controller type for automatic TLS passthrough.
+func (c *ButlerConfig) GetControlPlaneExposureControllerType() string {
+	if c.Spec.ControlPlaneExposure == nil {
+		return ""
+	}
+	return c.Spec.ControlPlaneExposure.ControllerType
+}

--- a/api/v1alpha1/clusterbootstrap_types.go
+++ b/api/v1alpha1/clusterbootstrap_types.go
@@ -99,6 +99,16 @@ type ControlPlaneExposureSpec struct {
 	// +optional
 	IngressClassName string `json:"ingressClassName,omitempty"`
 
+	// ControllerType specifies the ingress controller type for automatic TLS passthrough.
+	// Used when Mode is Ingress. Supported values:
+	// - "haproxy": Uses haproxy.org/ssl-passthrough annotation
+	// - "nginx": Uses nginx.ingress.kubernetes.io/ssl-passthrough annotation
+	// - "traefik": Creates IngressRouteTCP instead of standard Ingress
+	// - "generic": No automatic annotations, use custom annotations in Steward config
+	// +kubebuilder:validation:Enum=haproxy;nginx;traefik;generic
+	// +optional
+	ControllerType string `json:"controllerType,omitempty"`
+
 	// GatewayRef references the Gateway resource when Mode is Gateway.
 	// Format: "namespace/name"
 	// +optional

--- a/config/crd/bases/butler.butlerlabs.dev_butlerconfigs.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_butlerconfigs.yaml
@@ -70,6 +70,20 @@ spec:
                   This is a platform-level setting populated from ClusterBootstrap during
                   initial setup and inherited by all TenantClusters.
                 properties:
+                  controllerType:
+                    description: |-
+                      ControllerType specifies the ingress controller type for automatic TLS passthrough.
+                      Used when Mode is Ingress. Supported values:
+                      - "haproxy": Uses haproxy.org/ssl-passthrough annotation
+                      - "nginx": Uses nginx.ingress.kubernetes.io/ssl-passthrough annotation
+                      - "traefik": Creates IngressRouteTCP instead of standard Ingress
+                      - "generic": No automatic annotations, use custom annotations in Steward config
+                    enum:
+                    - haproxy
+                    - nginx
+                    - traefik
+                    - generic
+                    type: string
                   gatewayRef:
                     description: |-
                       GatewayRef references the Gateway resource when Mode is Gateway.

--- a/config/crd/bases/butler.butlerlabs.dev_clusterbootstraps.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_clusterbootstraps.yaml
@@ -465,6 +465,20 @@ spec:
                   and inherited by all TenantClusters.
                   Defaults to LoadBalancer mode if not specified.
                 properties:
+                  controllerType:
+                    description: |-
+                      ControllerType specifies the ingress controller type for automatic TLS passthrough.
+                      Used when Mode is Ingress. Supported values:
+                      - "haproxy": Uses haproxy.org/ssl-passthrough annotation
+                      - "nginx": Uses nginx.ingress.kubernetes.io/ssl-passthrough annotation
+                      - "traefik": Creates IngressRouteTCP instead of standard Ingress
+                      - "generic": No automatic annotations, use custom annotations in Steward config
+                    enum:
+                    - haproxy
+                    - nginx
+                    - traefik
+                    - generic
+                    type: string
                   gatewayRef:
                     description: |-
                       GatewayRef references the Gateway resource when Mode is Gateway.


### PR DESCRIPTION
## Summary

Add `controllerType` field to `ControlPlaneExposureSpec` for automatic TLS passthrough configuration.

## Changes

- Add `ControllerType` field with enum validation (`haproxy`, `nginx`, `traefik`, `generic`)
- Add `GetControlPlaneExposureControllerType()` helper method to ButlerConfig

## Supported Controllers

| Type | Behavior |
|------|----------|
| `haproxy` | Uses `haproxy.org/ssl-passthrough` annotation |
| `nginx` | Uses `nginx.ingress.kubernetes.io/ssl-passthrough` annotation |
| `traefik` | Creates IngressRouteTCP (standard Ingress doesn't support TLS passthrough) |
| `generic` | No automatic config, user provides custom annotations |

## Related PRs

- steward: butlerdotdev/steward#4
- capi-steward: butlerdotdev/cluster-api-control-plane-provider-steward#2