### PR TITLE
feat: expand AddonCategory enum with dns, database, messaging, service-mesh

### DIFF
--- a/api/v1alpha1/addondefinition_types.go
+++ b/api/v1alpha1/addondefinition_types.go
@@ -21,7 +21,7 @@ import (
 )
 
 // AddonCategory defines the category of an addon for UI grouping.
-// +kubebuilder:validation:Enum=cni;loadbalancer;storage;certmanager;ingress;observability;backup;gitops;security;other
+// +kubebuilder:validation:Enum=cni;loadbalancer;storage;certmanager;ingress;observability;backup;gitops;security;dns;database;messaging;service-mesh;other
 type AddonCategory string
 
 const (
@@ -34,6 +34,10 @@ const (
 	AddonCategoryBackup        AddonCategory = "backup"
 	AddonCategoryGitOps        AddonCategory = "gitops"
 	AddonCategorySecurity      AddonCategory = "security"
+	AddonCategoryDNS           AddonCategory = "dns"
+	AddonCategoryDatabase      AddonCategory = "database"
+	AddonCategoryMessaging     AddonCategory = "messaging"
+	AddonCategoryServiceMesh   AddonCategory = "service-mesh"
 	AddonCategoryOther         AddonCategory = "other"
 )
 

--- a/config/crd/bases/butler.butlerlabs.dev_addondefinitions.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_addondefinitions.yaml
@@ -87,6 +87,10 @@ spec:
                 - backup
                 - gitops
                 - security
+                - dns
+                - database
+                - messaging
+                - service-mesh
                 - other
                 type: string
               chart:


### PR DESCRIPTION
## Summary

- Adds 4 new values to the `AddonCategory` enum: `dns`, `database`, `messaging`, `service-mesh`
- Updates kubebuilder validation marker and regenerates CRD YAML
- Enables proper categorization of addons that were previously forced into `other`

## Changes

- `api/v1alpha1/addondefinition_types.go`: New enum constants + updated validation marker
- `config/crd/bases/butler.butlerlabs.dev_addondefinitions.yaml`: Regenerated with expanded enum

## Test plan

- [x] `make generate` — no deepcopy changes (expected for enum-only change)
- [x] `make manifests` — CRD YAML regenerated with new enum values
- [ ] Companion PR in butler-charts syncs the CRD and updates butler-addons chart to use new categories