### PR TITLE
feat: add ImageURN and VMSize to AzureProviderConfig

### DIFF
--- a/api/v1alpha1/providerconfig_types.go
+++ b/api/v1alpha1/providerconfig_types.go
@@ -228,6 +228,17 @@ type AzureProviderConfig struct {
 	// SubnetName is the subnet within the VNet.
 	// +optional
 	SubnetName string `json:"subnetName,omitempty"`
+
+	// VMSize is the default Azure VM size (e.g., "Standard_D4s_v3").
+	// +optional
+	VMSize string `json:"vmSize,omitempty"`
+
+	// ImageURN is the VM image reference. Supports three formats:
+	// - URN: "publisher:offer:sku:version" (e.g., "Canonical:UbuntuServer:18.04-LTS:latest")
+	// - Managed image resource ID: "/subscriptions/.../images/my-image"
+	// - Shared gallery image ID: "/subscriptions/.../galleries/.../images/.../versions/..."
+	// +optional
+	ImageURN string `json:"imageURN,omitempty"`
 }
 
 // AWSProviderConfig contains AWS-specific configuration.

--- a/config/crd/bases/butler.butlerlabs.dev_providerconfigs.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_providerconfigs.yaml
@@ -93,6 +93,13 @@ spec:
                   Azure contains Azure-specific configuration.
                   Required when provider is "azure".
                 properties:
+                  imageURN:
+                    description: |-
+                      ImageURN is the VM image reference. Supports three formats:
+                      - URN: "publisher:offer:sku:version" (e.g., "Canonical:UbuntuServer:18.04-LTS:latest")
+                      - Managed image resource ID: "/subscriptions/.../images/my-image"
+                      - Shared gallery image ID: "/subscriptions/.../galleries/.../images/.../versions/..."
+                    type: string
                   location:
                     description: Location is the Azure region.
                     type: string
@@ -104,6 +111,9 @@ spec:
                     type: string
                   subscriptionID:
                     description: SubscriptionID is the Azure subscription ID.
+                    type: string
+                  vmSize:
+                    description: VMSize is the default Azure VM size (e.g., "Standard_D4s_v3").
                     type: string
                   vnetName:
                     description: VNetName is the Azure Virtual Network name.


### PR DESCRIPTION
## Summary

- Add `ImageURN` and `VMSize` fields to `AzureProviderConfig` in the ProviderConfig CRD
- `ImageURN` supports Azure URN format, managed image resource IDs, and shared gallery image IDs
- `VMSize` configures the default Azure VM size (e.g., `Standard_D4s_v3`)
- Aligns Azure provider config with GCP's existing image/machine type fields

## Test plan

- [x] `make generate && make manifests` passes
- [x] `go vet ./...` passes
- [x] CRD YAML updated with new fields
- [x] Consumed by butler-provider-azure and butler-cli