### PR TITLE
fix: remove omitempty from worker status fields

### DIFF
--- a/api/v1alpha1/tenantcluster_types.go
+++ b/api/v1alpha1/tenantcluster_types.go
@@ -671,13 +671,15 @@ type TenantClusterStatus struct {
 	// +optional
 	ObservedState *ObservedClusterState `json:"observedState,omitempty"`
 
-	// WorkerNodesReady is the count of ready worker nodes
+	// WorkerNodesReady is the count of ready worker nodes.
+	// Zero is a valid value (no omitempty) to distinguish "0 ready" from "not set".
 	// +optional
-	WorkerNodesReady int32 `json:"workerNodesReady,omitempty"`
+	WorkerNodesReady int32 `json:"workerNodesReady"`
 
-	// WorkerNodesDesired is the desired count of worker nodes
+	// WorkerNodesDesired is the desired count of worker nodes.
+	// Zero is a valid value (no omitempty) to distinguish "0 desired" from "not set".
 	// +optional
-	WorkerNodesDesired int32 `json:"workerNodesDesired,omitempty"`
+	WorkerNodesDesired int32 `json:"workerNodesDesired"`
 
 	// IPAllocationRef references the node IP allocation from IPAM.
 	// +optional

--- a/config/crd/bases/butler.butlerlabs.dev_tenantclusters.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_tenantclusters.yaml
@@ -876,11 +876,15 @@ spec:
                   resources.
                 type: string
               workerNodesDesired:
-                description: WorkerNodesDesired is the desired count of worker nodes
+                description: |-
+                  WorkerNodesDesired is the desired count of worker nodes.
+                  Zero is a valid value (no omitempty) to distinguish "0 desired" from "not set".
                 format: int32
                 type: integer
               workerNodesReady:
-                description: WorkerNodesReady is the count of ready worker nodes
+                description: |-
+                  WorkerNodesReady is the count of ready worker nodes.
+                  Zero is a valid value (no omitempty) to distinguish "0 ready" from "not set".
                 format: int32
                 type: integer
             type: object


### PR DESCRIPTION
## Summary

- Remove `omitempty` from `WorkerNodesReady` and `WorkerNodesDesired` JSON tags on `TenantClusterStatus`
- `int32` with `omitempty` drops `0` from JSON, making "0 ready" indistinguishable from "not set"
- Keep `+optional` marker so the CRD schema doesn't make these fields required
- CRD YAML regenerated via `make generate && make manifests`

## Test plan

- [x] `make generate && make manifests` — CRD YAML updated, fields not in `required` list
- [x] Verified on butler-beta: `workerNodesReady: 0` serialized correctly for Installing clusters