### PR TITLE
feat: add NTP time server configuration fields

### DIFF
--- a/api/v1alpha1/butlerconfig_types.go
+++ b/api/v1alpha1/butlerconfig_types.go
@@ -102,6 +102,13 @@ type ButlerConfigSpec struct {
 	// +optional
 	SSHAuthorizedKey string `json:"sshAuthorizedKey,omitempty"`
 
+	// DefaultTimeServers are the platform-wide default NTP servers for Talos worker nodes.
+	// Can be overridden per-provider via ProviderConfig.spec.network.timeServers
+	// or per-cluster via TenantCluster.spec.timeServers.
+	// If empty, falls back to pool.ntp.org.
+	// +optional
+	DefaultTimeServers []string `json:"defaultTimeServers,omitempty"`
+
 	// Audit configures the platform audit log.
 	// +optional
 	Audit *AuditConfig `json:"audit,omitempty"`
@@ -398,6 +405,15 @@ func (c *ButlerConfig) GetNotificationsWebhookURL() string {
 		return ""
 	}
 	return c.Spec.Notifications.WebhookURL
+}
+
+// GetDefaultTimeServers returns the platform-wide default NTP servers.
+// Returns nil if not configured (caller should fall back to pool.ntp.org).
+func (c *ButlerConfig) GetDefaultTimeServers() []string {
+	if c == nil {
+		return nil
+	}
+	return c.Spec.DefaultTimeServers
 }
 
 // ImageFactoryConfig configures the Butler Image Factory.

--- a/api/v1alpha1/providerconfig_types.go
+++ b/api/v1alpha1/providerconfig_types.go
@@ -362,6 +362,12 @@ type ProviderNetworkConfig struct {
 	// +optional
 	DNSServers []string `json:"dnsServers,omitempty"`
 
+	// TimeServers are the default NTP servers for Talos worker nodes on this provider.
+	// Falls back to ButlerConfig.spec.defaultTimeServers if empty.
+	// Required on networks where the Talos default (time.cloudflare.com) is unreachable.
+	// +optional
+	TimeServers []string `json:"timeServers,omitempty"`
+
 	// LoadBalancer configures load balancer IP allocation defaults.
 	// +optional
 	LoadBalancer *ProviderLBConfig `json:"loadBalancer,omitempty"`

--- a/api/v1alpha1/tenantcluster_types.go
+++ b/api/v1alpha1/tenantcluster_types.go
@@ -102,6 +102,13 @@ type TenantClusterSpec struct {
 	// +optional
 	Addons AddonsSpec `json:"addons,omitempty"`
 
+	// TimeServers overrides the NTP servers used by Talos worker nodes.
+	// If empty, falls back to ProviderConfig.spec.network.timeServers,
+	// then ButlerConfig.spec.defaultTimeServers, then pool.ntp.org.
+	// Required on networks where the Talos default (time.cloudflare.com) is unreachable.
+	// +optional
+	TimeServers []string `json:"timeServers,omitempty"`
+
 	// InfrastructureOverride allows overriding provider-specific settings.
 	// These take precedence over ProviderConfig defaults.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -447,6 +447,11 @@ func (in *ButlerConfigSpec) DeepCopyInto(out *ButlerConfigSpec) {
 		*out = new(ImageFactoryConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DefaultTimeServers != nil {
+		in, out := &in.DefaultTimeServers, &out.DefaultTimeServers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Audit != nil {
 		in, out := &in.Audit, &out.Audit
 		*out = new(AuditConfig)
@@ -3139,6 +3144,11 @@ func (in *ProviderNetworkConfig) DeepCopyInto(out *ProviderNetworkConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.TimeServers != nil {
+		in, out := &in.TimeServers, &out.TimeServers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.LoadBalancer != nil {
 		in, out := &in.LoadBalancer, &out.LoadBalancer
 		*out = new(ProviderLBConfig)
@@ -3938,6 +3948,11 @@ func (in *TenantClusterSpec) DeepCopyInto(out *TenantClusterSpec) {
 	in.Networking.DeepCopyInto(&out.Networking)
 	out.ManagementPolicy = in.ManagementPolicy
 	in.Addons.DeepCopyInto(&out.Addons)
+	if in.TimeServers != nil {
+		in, out := &in.TimeServers, &out.TimeServers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.InfrastructureOverride != nil {
 		in, out := &in.InfrastructureOverride, &out.InfrastructureOverride
 		*out = new(InfrastructureOverride)

--- a/config/crd/bases/butler.butlerlabs.dev_butlerconfigs.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_butlerconfigs.yaml
@@ -344,6 +344,15 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              defaultTimeServers:
+                description: |-
+                  DefaultTimeServers are the platform-wide default NTP servers for Talos worker nodes.
+                  Can be overridden per-provider via ProviderConfig.spec.network.timeServers
+                  or per-cluster via TenantCluster.spec.timeServers.
+                  If empty, falls back to pool.ntp.org.
+                items:
+                  type: string
+                type: array
               gitProvider:
                 description: |-
                   GitProvider configures the default Git provider for GitOps operations.

--- a/config/crd/bases/butler.butlerlabs.dev_providerconfigs.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_providerconfigs.yaml
@@ -349,6 +349,14 @@ spec:
                     description: Subnet is the network name for VM placement (e.g.,
                       "VM Network - VLAN 40").
                     type: string
+                  timeServers:
+                    description: |-
+                      TimeServers are the default NTP servers for Talos worker nodes on this provider.
+                      Falls back to ButlerConfig.spec.defaultTimeServers if empty.
+                      Required on networks where the Talos default (time.cloudflare.com) is unreachable.
+                    items:
+                      type: string
+                    type: array
                 type: object
               nutanix:
                 description: |-

--- a/config/crd/bases/butler.butlerlabs.dev_tenantclusters.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_tenantclusters.yaml
@@ -534,6 +534,15 @@ spec:
                 required:
                 - name
                 type: object
+              timeServers:
+                description: |-
+                  TimeServers overrides the NTP servers used by Talos worker nodes.
+                  If empty, falls back to ProviderConfig.spec.network.timeServers,
+                  then ButlerConfig.spec.defaultTimeServers, then pool.ntp.org.
+                  Required on networks where the Talos default (time.cloudflare.com) is unreachable.
+                items:
+                  type: string
+                type: array
               workers:
                 description: Workers configures the worker nodes.
                 properties:


### PR DESCRIPTION
## Summary

- Adds `TimeServers []string` to `TenantClusterSpec` for per-cluster NTP override
- Adds `TimeServers []string` to `ProviderNetworkConfig` for per-provider NTP defaults
- Adds `DefaultTimeServers []string` to `ButlerConfigSpec` for platform-wide NTP defaults
- Adds `GetDefaultTimeServers()` helper on ButlerConfig

## Context

Talos Linux blocks kubelet startup until NTP time sync succeeds. The default NTP server (`time.cloudflare.com`) is unreachable on networks where UDP 123 outbound is blocked. This adds configurable NTP servers with a three-level fallback chain:

`TenantCluster.spec.timeServers` > `ProviderConfig.spec.network.timeServers` > `ButlerConfig.spec.defaultTimeServers` > `pool.ntp.org`

## Test plan

- [x] `go generate ./...` produces clean deepcopy
- [x] CRDs applied to live cluster, verified with `kubectl get crd`
- [x] Validated end-to-end on Company 1 Nutanix cluster — worker registered successfully with `ntp01.phibred.com`