### PR TITLE
fix: add LabelPlatformLB constant for elastic IPAM filtering

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -284,6 +284,11 @@ const (
 	// parent Team defines any environment. Absence is allowed only when
 	// the parent Team has no environments. Immutable after create.
 	LabelEnvironment = "butler.butlerlabs.dev/environment"
+
+	// LabelPlatformLB identifies LoadBalancer services managed by butler platform
+	// addons (e.g., Traefik ingress controller). These are excluded from elastic
+	// IPAM usage counting since they are infrastructure, not tenant workload LBs.
+	LabelPlatformLB = "butler.butlerlabs.dev/platform-lb"
 )
 
 // Butler-specific annotations.


### PR DESCRIPTION
## Summary

- Adds `LabelPlatformLB` (`butler.butlerlabs.dev/platform-lb`) label constant
- Platform LB services (Traefik ingress controller) use this label so the elastic IPAM counter can exclude them from usage calculations
- Companion PR in butler-controller applies the label during Traefik install and filters on it in `countUsedLBIPs`

## Context

Each tenant cluster's Traefik LB service is currently counted as a "used" IP in elastic IPAM, inflating usage and making shrink more aggressive. Labeling platform LBs allows the controller to distinguish infrastructure services from tenant workload services.

Part of butler-controller#59.

## Test plan

- [ ] Constant compiles (`go build ./...`)
- [ ] No breaking changes (additive only)