### PR TITLE
Add Tier field to AddonDefinitionSpec for GitOps export placement

### DIFF
--- a/api/v1alpha1/addondefinition_types.go
+++ b/api/v1alpha1/addondefinition_types.go
@@ -41,6 +41,18 @@ const (
 	AddonCategoryOther         AddonCategory = "other"
 )
 
+// AddonTier controls which directory an addon is placed in during
+// GitOps export. Infrastructure-tier addons provide CRDs or platform
+// prerequisites that other addons depend on. Apps-tier addons are
+// regular workloads. See ADR-015 for design rationale.
+// +kubebuilder:validation:Enum=infrastructure;apps
+type AddonTier string
+
+const (
+	AddonTierInfrastructure AddonTier = "infrastructure"
+	AddonTierApps           AddonTier = "apps"
+)
+
 // AddonDefinitionSpec defines the desired state of AddonDefinition.
 // An AddonDefinition is a cluster-scoped resource that defines an addon
 // available for installation in tenant clusters.
@@ -81,6 +93,17 @@ type AddonDefinitionSpec struct {
 	// +kubebuilder:default=false
 	// +optional
 	Platform bool `json:"platform,omitempty"`
+
+	// Tier controls which directory the addon is placed in during GitOps
+	// export: "infrastructure" or "apps". Infrastructure-tier addons
+	// provide CRDs or platform prerequisites that must exist before
+	// workloads that consume them. When set, this takes precedence over
+	// the Platform field for directory placement. When empty, inferred
+	// from Platform: platform addons default to "infrastructure",
+	// non-platform addons default to "apps".
+	// See ADR-015 for design rationale. Tracked in butler-controller#79.
+	// +optional
+	Tier AddonTier `json:"tier,omitempty"`
 
 	// DependsOn lists addon names that must be installed first.
 	// The TenantAddon controller will wait for these dependencies
@@ -234,4 +257,18 @@ func (a *AddonDefinition) IsBuiltIn() bool {
 		return false
 	}
 	return a.Labels["butler.butlerlabs.dev/source"] == "builtin"
+}
+
+// GetEffectiveTier returns the GitOps directory tier for this addon.
+// When Tier is set explicitly, it takes precedence. Otherwise, the
+// tier is inferred from Platform: platform addons are "infrastructure",
+// non-platform addons are "apps".
+func (a *AddonDefinition) GetEffectiveTier() string {
+	if a.Spec.Tier != "" {
+		return string(a.Spec.Tier)
+	}
+	if a.Spec.Platform {
+		return string(AddonTierInfrastructure)
+	}
+	return string(AddonTierApps)
 }

--- a/api/v1alpha1/addondefinition_types_test.go
+++ b/api/v1alpha1/addondefinition_types_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "testing"
+
+func TestGetEffectiveTier(t *testing.T) {
+	tests := []struct {
+		name     string
+		tier     AddonTier
+		platform bool
+		want     string
+	}{
+		{
+			name: "explicit infrastructure tier",
+			tier: AddonTierInfrastructure,
+			want: "infrastructure",
+		},
+		{
+			name: "explicit apps tier",
+			tier: AddonTierApps,
+			want: "apps",
+		},
+		{
+			name:     "explicit tier overrides platform",
+			tier:     AddonTierApps,
+			platform: true,
+			want:     "apps",
+		},
+		{
+			name:     "platform fallback to infrastructure",
+			platform: true,
+			want:     "infrastructure",
+		},
+		{
+			name: "non-platform fallback to apps",
+			want: "apps",
+		},
+		{
+			name:     "explicit infrastructure with platform true is redundant but valid",
+			tier:     AddonTierInfrastructure,
+			platform: true,
+			want:     "infrastructure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ad := &AddonDefinition{
+				Spec: AddonDefinitionSpec{
+					Tier:     tt.tier,
+					Platform: tt.platform,
+				},
+			}
+			got := ad.GetEffectiveTier()
+			if got != tt.want {
+				t.Errorf("GetEffectiveTier() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/crd/bases/butler.butlerlabs.dev_addondefinitions.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_addondefinitions.yaml
@@ -204,6 +204,20 @@ spec:
                   Platform addons are installed during cluster bootstrap and cannot
                   be uninstalled via the UI. They appear in a separate section.
                 type: boolean
+              tier:
+                description: |-
+                  Tier controls which directory the addon is placed in during GitOps
+                  export: "infrastructure" or "apps". Infrastructure-tier addons
+                  provide CRDs or platform prerequisites that must exist before
+                  workloads that consume them. When set, this takes precedence over
+                  the Platform field for directory placement. When empty, inferred
+                  from Platform: platform addons default to "infrastructure",
+                  non-platform addons default to "apps".
+                  See ADR-015 for design rationale. Tracked in butler-controller#79.
+                enum:
+                - infrastructure
+                - apps
+                type: string
             required:
             - category
             - chart


### PR DESCRIPTION
## Summary

- Adds `AddonTier` enum type (`infrastructure`, `apps`) to the addon API
- Adds optional `Tier` field to `AddonDefinitionSpec` with kubebuilder enum validation
- Adds `GetEffectiveTier()` helper on `AddonDefinition` with table-driven tests (6 cases)
- Regenerated CRDs and deepcopy via `make generate manifests`

When `Tier` is set, it takes precedence over the `Platform` boolean for determining the GitOps export directory. When empty, the existing behavior is preserved: platform addons go to `infrastructure/`, non-platform addons go to `apps/`.

## Context

The GitOps export feature in butler-server uses `AddonDefinition.spec.platform` to decide whether an addon belongs in `infrastructure/` or `apps/`. This works for the six bootstrap addons (cilium, metallb, cert-manager, longhorn, traefik, metrics-server) where platform=true correctly maps to infrastructure. But several non-platform addons also belong in `infrastructure/` from a Flux ordering perspective: prometheus-operator (provides ServiceMonitor CRDs), sealed-secrets (provides SealedSecret CRDs), external-secrets, and cnpg. These are optional and uninstallable (not platform), but they provide CRDs that other addons depend on (infrastructure).

The `Tier` field separates the directory-placement concern from the lifecycle concern, letting butler-server place CRD-providing addons in `infrastructure/` without marking them as platform.

ADR: butlerdotdev/butler-server#59

Tracking issue: butlerdotdev/butler-controller#79

This is PR 1 of 3. PR 2 (butler-server) updates the export logic to read `Tier`. PR 3 (butler-charts) sets `tier: infrastructure` on the four affected addons and syncs the CRD.

## Test plan

- [x] `make generate manifests` succeeds
- [x] `make fmt vet` passes
- [x] `go build ./...` succeeds
- [x] `go test ./api/v1alpha1/...` passes (6 cases for GetEffectiveTier)
- [ ] Verify generated CRD YAML includes `tier` with enum validation (`infrastructure`, `apps`)
- [ ] Verify `tier` field description references ADR-015