### PR TITLE
Add IconData field to AddonDefinitionSpec

### DIFF
--- a/api/v1alpha1/addondefinition_types.go
+++ b/api/v1alpha1/addondefinition_types.go
@@ -78,6 +78,16 @@ type AddonDefinitionSpec struct {
 	// +optional
 	Icon string `json:"icon,omitempty"`
 
+	// IconData is a base64-encoded SVG used for inline icon rendering
+	// in the addon catalog UI. Allows self-contained operation without
+	// external image hosting, which is required for air-gapped deployments.
+	// Custom addon authors set this field to embed their own project logo.
+	// When present, takes precedence over the Icon emoji field.
+	// Tracked in butlerdotdev/butler-api#37.
+	// +kubebuilder:validation:MaxLength=131072
+	// +optional
+	IconData string `json:"iconData,omitempty"`
+
 	// Chart specifies the Helm chart to install.
 	// +kubebuilder:validation:Required
 	Chart AddonChartSpec `json:"chart"`

--- a/api/v1alpha1/addondefinition_types_test.go
+++ b/api/v1alpha1/addondefinition_types_test.go
@@ -121,6 +121,15 @@ func TestIconDataField(t *testing.T) {
 			if present != tt.wantJSON {
 				t.Errorf("iconData in JSON = %v, want %v", present, tt.wantJSON)
 			}
+
+			// Round-trip: unmarshal back and verify value preserved
+			var spec AddonDefinitionSpec
+			if err := json.Unmarshal(data, &spec); err != nil {
+				t.Fatalf("failed to unmarshal spec: %v", err)
+			}
+			if spec.IconData != tt.iconData {
+				t.Errorf("round-trip IconData = %q, want %q", spec.IconData, tt.iconData)
+			}
 		})
 	}
 }

--- a/api/v1alpha1/addondefinition_types_test.go
+++ b/api/v1alpha1/addondefinition_types_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package v1alpha1
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestGetEffectiveTier(t *testing.T) {
 	tests := []struct {
@@ -69,6 +72,54 @@ func TestGetEffectiveTier(t *testing.T) {
 			got := ad.GetEffectiveTier()
 			if got != tt.want {
 				t.Errorf("GetEffectiveTier() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIconDataField(t *testing.T) {
+	tests := []struct {
+		name     string
+		iconData string
+		wantJSON bool
+	}{
+		{
+			name:     "iconData set with base64 SVG",
+			iconData: "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4=",
+			wantJSON: true,
+		},
+		{
+			name:     "iconData omitted when empty",
+			iconData: "",
+			wantJSON: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ad := &AddonDefinition{
+				Spec: AddonDefinitionSpec{
+					IconData: tt.iconData,
+				},
+			}
+
+			if ad.Spec.IconData != tt.iconData {
+				t.Errorf("IconData = %q, want %q", ad.Spec.IconData, tt.iconData)
+			}
+
+			data, err := json.Marshal(ad.Spec)
+			if err != nil {
+				t.Fatalf("failed to marshal spec: %v", err)
+			}
+
+			var raw map[string]interface{}
+			if err := json.Unmarshal(data, &raw); err != nil {
+				t.Fatalf("failed to unmarshal spec: %v", err)
+			}
+
+			_, present := raw["iconData"]
+			if present != tt.wantJSON {
+				t.Errorf("iconData in JSON = %v, want %v", present, tt.wantJSON)
 			}
 		})
 	}

--- a/config/crd/bases/butler.butlerlabs.dev_addondefinitions.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_addondefinitions.yaml
@@ -174,6 +174,16 @@ spec:
                 description: Icon is an emoji or icon identifier for UI display.
                 maxLength: 8
                 type: string
+              iconData:
+                description: |-
+                  IconData is a base64-encoded SVG used for inline icon rendering
+                  in the addon catalog UI. Allows self-contained operation without
+                  external image hosting, which is required for air-gapped deployments.
+                  Custom addon authors set this field to embed their own project logo.
+                  When present, takes precedence over the Icon emoji field.
+                  Tracked in butlerdotdev/butler-api#37.
+                maxLength: 131072
+                type: string
               links:
                 description: Links provides URLs for documentation, source, etc.
                 properties:


### PR DESCRIPTION
## Context

The addon catalog UI redesign (butlerdotdev/butler-console#58) needs to render project logos for each addon. The current approach bundles SVGs as static assets in the console repo, which prevents custom addon authors from providing their own icons without modifying the console source. It also breaks in air-gapped deployments where external image URLs aren't reachable.

This is PR 1 of a 4-PR cross-repo chain that ships inline icon rendering end-to-end:

1. **butler-api** — add IconData field (this PR)
2. **butler-server** — bump butler-api dep, surface iconData in API responses
3. **butler-charts** — populate iconData on all 27 built-in addons
4. **butler-console** — update AddonIcon component to read iconData

## Changes

- Add `IconData` field to `AddonDefinitionSpec` — optional string, base64-encoded SVG content
- Kubebuilder validation: `MaxLength=131072` (128KB cap)
- `omitempty` so it doesn't appear in serialized output when unset
- Field comment documents purpose, precedence over Icon emoji, and air-gapped use case
- Regenerated CRDs via `make generate manifests`
- Table-driven tests: field presence when set, omitempty behavior when empty, round-trip serialization

Same pattern as the Tier field addition in #35.

## Test plan

- [x] `make generate manifests` succeeds
- [x] `go test ./api/v1alpha1/...` passes (2 cases for IconData, 6 for GetEffectiveTier)
- [x] Generated CRD YAML includes `iconData` with `maxLength: 131072`
- [x] `iconData` field description matches Go comment
- [x] No drift in unrelated CRD fields

Tracked in #37.