### PR TITLE
feat(api): add LastSeenGroups and TeamsResolvedAt to UserStatus

### DIFF
--- a/api/v1alpha1/user_types.go
+++ b/api/v1alpha1/user_types.go
@@ -171,10 +171,35 @@ type UserStatus struct {
 	// +optional
 	LockedUntil *metav1.Time `json:"lockedUntil,omitempty"`
 
+	// LastSeenGroups contains the IdP group identifiers from the user's most
+	// recent OIDC token. Written by butler-server at login. Used by the
+	// butler-controller User reconciler to resolve group-based Team membership
+	// without requiring the user to be actively logged in.
+	//
+	// Group identifiers are IdP-specific: UUIDs for Microsoft Entra, email-style
+	// for Google Workspace, plain names for others. Values are stored exactly as
+	// received from the IdP (no normalization). The Team resolution logic
+	// normalizes at match time.
+	// +optional
+	LastSeenGroups []string `json:"lastSeenGroups,omitempty"`
+
 	// Teams lists the teams this user belongs to (resolved from Team CRDs).
 	// This is informational and updated periodically.
 	// +optional
 	Teams []UserTeamMembership `json:"teams,omitempty"`
+
+	// TeamsResolvedAt is when status.teams was last successfully resolved
+	// by the butler-controller User reconciler. Updated atomically with
+	// status.teams on conditional writes (only when resolved teams differ
+	// from current status.teams). Used by the butler_user_status_stale_age_seconds
+	// metric to surface silent degradation in team resolution.
+	//
+	// When nil (pre-upgrade User CRDs or never-resolved Users), stale_age
+	// computation falls back to the User's creationTimestamp. This produces
+	// the worst-case stale_age value, ensuring unresolved users are visible
+	// in monitoring alerts.
+	// +optional
+	TeamsResolvedAt *metav1.Time `json:"teamsResolvedAt,omitempty"`
 
 	// Conditions represent the latest available observations.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -4237,10 +4237,19 @@ func (in *UserStatus) DeepCopyInto(out *UserStatus) {
 		in, out := &in.LockedUntil, &out.LockedUntil
 		*out = (*in).DeepCopy()
 	}
+	if in.LastSeenGroups != nil {
+		in, out := &in.LastSeenGroups, &out.LastSeenGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Teams != nil {
 		in, out := &in.Teams, &out.Teams
 		*out = make([]UserTeamMembership, len(*in))
 		copy(*out, *in)
+	}
+	if in.TeamsResolvedAt != nil {
+		in, out := &in.TeamsResolvedAt, &out.TeamsResolvedAt
+		*out = (*in).DeepCopy()
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions

--- a/config/crd/bases/butler.butlerlabs.dev_users.yaml
+++ b/config/crd/bases/butler.butlerlabs.dev_users.yaml
@@ -272,6 +272,20 @@ spec:
                   in.
                 format: date-time
                 type: string
+              lastSeenGroups:
+                description: |-
+                  LastSeenGroups contains the IdP group identifiers from the user's most
+                  recent OIDC token. Written by butler-server at login. Used by the
+                  butler-controller User reconciler to resolve group-based Team membership
+                  without requiring the user to be actively logged in.
+
+                  Group identifiers are IdP-specific: UUIDs for Microsoft Entra, email-style
+                  for Google Workspace, plain names for others. Values are stored exactly as
+                  received from the IdP (no normalization). The Team resolution logic
+                  normalizes at match time.
+                items:
+                  type: string
+                type: array
               lockedUntil:
                 description: |-
                   LockedUntil is set when the account is temporarily locked due to failed attempts.
@@ -344,6 +358,20 @@ spec:
                   - role
                   type: object
                 type: array
+              teamsResolvedAt:
+                description: |-
+                  TeamsResolvedAt is when status.teams was last successfully resolved
+                  by the butler-controller User reconciler. Updated atomically with
+                  status.teams on conditional writes (only when resolved teams differ
+                  from current status.teams). Used by the butler_user_status_stale_age_seconds
+                  metric to surface silent degradation in team resolution.
+
+                  When nil (pre-upgrade User CRDs or never-resolved Users), stale_age
+                  computation falls back to the User's creationTimestamp. This produces
+                  the worst-case stale_age value, ensuring unresolved users are visible
+                  in monitoring alerts.
+                format: date-time
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
## Summary

- Adds `LastSeenGroups []string` to `UserStatus` for persisting IdP group identifiers from OIDC tokens at login
- Adds `TeamsResolvedAt *metav1.Time` to `UserStatus` for staleness detection of resolved team membership
- Regenerated deepcopy and CRD manifest via `make generate && make manifests`

Both fields are optional and additive. Pre-upgrade User CRDs remain valid. No behavior change in this PR; writers are added in subsequent butler-server and butler-controller changes.

Spec: `~/code/.secrets/butler-user-team-membership-spec.md`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
- [x] deepcopy handles `*metav1.Time` pointer (nil check + DeepCopy)
- [x] CRD YAML shows `lastSeenGroups` as array of strings
- [x] CRD YAML shows `teamsResolvedAt` as date-time format string