### PR TITLE
feat(api): add resolution test fixtures for cross-consumer drift protection

### DIFF
--- a/testdata/resolution/01_empty_no_access.json
+++ b/testdata/resolution/01_empty_no_access.json
@@ -1,0 +1,22 @@
+{
+  "name": "empty_no_access",
+  "description": "No lastSeenGroups and no manual access produces no team memberships",
+  "input": {
+    "email": "nobody@corteva.com",
+    "lastSeenGroups": null,
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "admin"}
+          ],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "viewer"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": []
+}

--- a/testdata/resolution/02_manual_only.json
+++ b/testdata/resolution/02_manual_only.json
@@ -1,0 +1,33 @@
+{
+  "name": "manual_only",
+  "description": "Manual access resolves without lastSeenGroups (nil groups, pre-SSO login)",
+  "input": {
+    "email": "alice@corteva.com",
+    "lastSeenGroups": null,
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "admin"}
+          ],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "viewer"}
+          ]
+        }
+      },
+      {
+        "name": "data-science",
+        "access": {
+          "users": [
+            {"name": "bob@corteva.com", "role": "operator"}
+          ],
+          "groups": []
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "platform-engineering", "role": "admin"}
+  ]
+}

--- a/testdata/resolution/03_groups_no_match.json
+++ b/testdata/resolution/03_groups_no_match.json
@@ -1,0 +1,22 @@
+{
+  "name": "groups_no_match",
+  "description": "lastSeenGroups present but no team configures matching groups",
+  "input": {
+    "email": "carol@corteva.com",
+    "lastSeenGroups": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "admin"}
+          ],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "viewer"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": []
+}

--- a/testdata/resolution/04_group_single_team.json
+++ b/testdata/resolution/04_group_single_team.json
@@ -1,0 +1,31 @@
+{
+  "name": "group_single_team",
+  "description": "lastSeenGroups matches one team via UUID group identifier",
+  "input": {
+    "email": "carol@corteva.com",
+    "lastSeenGroups": ["b3a1c2d4-5e6f-7890-abcd-ef1234567890"],
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "operator"}
+          ]
+        }
+      },
+      {
+        "name": "data-science",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "f9e8d7c6-b5a4-3210-fedc-ba9876543210", "role": "viewer"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "platform-engineering", "role": "operator"}
+  ]
+}

--- a/testdata/resolution/05_group_multiple_teams.json
+++ b/testdata/resolution/05_group_multiple_teams.json
@@ -1,0 +1,46 @@
+{
+  "name": "group_multiple_teams",
+  "description": "lastSeenGroups matches groups on three teams with deterministic sorted output",
+  "input": {
+    "email": "carol@corteva.com",
+    "lastSeenGroups": [
+      "b3a1c2d4-5e6f-7890-abcd-ef1234567890",
+      "f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+    ],
+    "teams": [
+      {
+        "name": "seed-research",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "f9e8d7c6-b5a4-3210-fedc-ba9876543210", "role": "viewer"}
+          ]
+        }
+      },
+      {
+        "name": "crop-protection",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "admin"}
+          ]
+        }
+      },
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "operator"},
+            {"name": "f9e8d7c6-b5a4-3210-fedc-ba9876543210", "role": "viewer"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "crop-protection", "role": "admin"},
+    {"name": "platform-engineering", "role": "operator"},
+    {"name": "seed-research", "role": "viewer"}
+  ]
+}

--- a/testdata/resolution/06_manual_and_group_highest_role.json
+++ b/testdata/resolution/06_manual_and_group_highest_role.json
@@ -1,0 +1,24 @@
+{
+  "name": "manual_and_group_highest_role",
+  "description": "Manual access as viewer and group access as admin on same team: admin wins",
+  "input": {
+    "email": "alice@corteva.com",
+    "lastSeenGroups": ["b3a1c2d4-5e6f-7890-abcd-ef1234567890"],
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "viewer"}
+          ],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "admin"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "platform-engineering", "role": "admin"}
+  ]
+}

--- a/testdata/resolution/07_manual_and_group_manual_higher.json
+++ b/testdata/resolution/07_manual_and_group_manual_higher.json
@@ -1,0 +1,24 @@
+{
+  "name": "manual_and_group_manual_higher",
+  "description": "Manual access as admin and group access as viewer on same team: admin wins",
+  "input": {
+    "email": "alice@corteva.com",
+    "lastSeenGroups": ["b3a1c2d4-5e6f-7890-abcd-ef1234567890"],
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "admin"}
+          ],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "viewer"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "platform-engineering", "role": "admin"}
+  ]
+}

--- a/testdata/resolution/08_group_normalization_uuid.json
+++ b/testdata/resolution/08_group_normalization_uuid.json
@@ -1,0 +1,22 @@
+{
+  "name": "group_normalization_uuid",
+  "description": "UUID group identifiers match case-insensitively (Entra ID returns uppercase UUIDs)",
+  "input": {
+    "email": "carol@corteva.com",
+    "lastSeenGroups": ["B3A1C2D4-5E6F-7890-ABCD-EF1234567890"],
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "operator"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "platform-engineering", "role": "operator"}
+  ]
+}

--- a/testdata/resolution/09_group_normalization_email.json
+++ b/testdata/resolution/09_group_normalization_email.json
@@ -1,0 +1,31 @@
+{
+  "name": "group_normalization_email",
+  "description": "Email-style group from IdP matches plain name configured on team via domain stripping",
+  "input": {
+    "email": "carol@corteva.com",
+    "lastSeenGroups": ["platform-engineering@corteva.com"],
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "platform-engineering", "role": "operator"}
+          ]
+        }
+      },
+      {
+        "name": "data-science",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "data-science@corteva.com", "role": "viewer"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "platform-engineering", "role": "operator"}
+  ]
+}

--- a/testdata/resolution/10_group_normalization_ldap.json
+++ b/testdata/resolution/10_group_normalization_ldap.json
@@ -1,0 +1,22 @@
+{
+  "name": "group_normalization_ldap",
+  "description": "LDAP DN format configured on team matches plain group name from IdP via CN extraction",
+  "input": {
+    "email": "carol@corteva.com",
+    "lastSeenGroups": ["devops"],
+    "teams": [
+      {
+        "name": "devops-team",
+        "access": {
+          "users": [],
+          "groups": [
+            {"name": "CN=DevOps,OU=Groups,DC=corp,DC=corteva,DC=com", "role": "admin"}
+          ]
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "devops-team", "role": "admin"}
+  ]
+}

--- a/testdata/resolution/11_sort_determinism.json
+++ b/testdata/resolution/11_sort_determinism.json
@@ -1,0 +1,62 @@
+{
+  "name": "sort_determinism",
+  "description": "Five teams in reverse alphabetical order in input produce ascending sorted output",
+  "input": {
+    "email": "alice@corteva.com",
+    "lastSeenGroups": null,
+    "teams": [
+      {
+        "name": "zeta-operations",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "viewer"}
+          ],
+          "groups": []
+        }
+      },
+      {
+        "name": "seed-research",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "operator"}
+          ],
+          "groups": []
+        }
+      },
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "admin"}
+          ],
+          "groups": []
+        }
+      },
+      {
+        "name": "data-science",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "viewer"}
+          ],
+          "groups": []
+        }
+      },
+      {
+        "name": "crop-protection",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "operator"}
+          ],
+          "groups": []
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "crop-protection", "role": "operator"},
+    {"name": "data-science", "role": "viewer"},
+    {"name": "platform-engineering", "role": "admin"},
+    {"name": "seed-research", "role": "operator"},
+    {"name": "zeta-operations", "role": "viewer"}
+  ]
+}

--- a/testdata/resolution/12_default_role.json
+++ b/testdata/resolution/12_default_role.json
@@ -1,0 +1,22 @@
+{
+  "name": "default_role",
+  "description": "Empty role string on manual access defaults to viewer",
+  "input": {
+    "email": "alice@corteva.com",
+    "lastSeenGroups": null,
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": ""}
+          ],
+          "groups": []
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "platform-engineering", "role": "viewer"}
+  ]
+}

--- a/testdata/resolution/13_empty_lastseengroups_explicit.json
+++ b/testdata/resolution/13_empty_lastseengroups_explicit.json
@@ -1,0 +1,33 @@
+{
+  "name": "empty_lastseengroups_explicit",
+  "description": "Explicit empty slice for lastSeenGroups (not null) resolves manual access only, same as null. Catches divergence between len(groups)==0 short-circuit and groups!=nil check.",
+  "input": {
+    "email": "alice@corteva.com",
+    "lastSeenGroups": [],
+    "teams": [
+      {
+        "name": "platform-engineering",
+        "access": {
+          "users": [
+            {"name": "alice@corteva.com", "role": "admin"}
+          ],
+          "groups": [
+            {"name": "b3a1c2d4-5e6f-7890-abcd-ef1234567890", "role": "viewer"}
+          ]
+        }
+      },
+      {
+        "name": "data-science",
+        "access": {
+          "users": [
+            {"name": "bob@corteva.com", "role": "operator"}
+          ],
+          "groups": []
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "platform-engineering", "role": "admin"}
+  ]
+}

--- a/testdata/resolution/README.md
+++ b/testdata/resolution/README.md
@@ -1,0 +1,77 @@
+# Resolution Test Fixtures
+
+Shared test fixtures for User-Team membership resolution. Both butler-server
+and butler-controller implement the resolution logic independently (per the
+Factor-1 decision in the User-Team membership spec). These fixtures encode
+the resolution contract so that drift between implementations is detected
+by CI rather than discovered in production.
+
+## How it works
+
+Each JSON file describes one test case: a set of inputs (user email,
+lastSeenGroups, Team CRDs) and the expected output (sorted list of
+UserTeamMembership). Consumer tests import this package and assert their
+resolution function produces output matching each fixture.
+
+## Fixture format
+
+```json
+{
+  "name": "descriptive_case_name",
+  "description": "What this fixture tests",
+  "input": {
+    "email": "user@example.com",
+    "lastSeenGroups": ["group-id-1"],
+    "teams": [
+      {
+        "name": "team-name",
+        "access": {
+          "users": [{"name": "user@example.com", "role": "admin"}],
+          "groups": [{"name": "group-id-1", "role": "viewer"}]
+        }
+      }
+    ]
+  },
+  "expected": [
+    {"name": "team-name", "role": "admin"}
+  ]
+}
+```
+
+## Contract assertions
+
+- Expected output is sorted by team name ascending
+- When manual and group access overlap on the same team, the highest role wins
+- Empty role strings default to "viewer"
+- Group matching is symmetric: both user-side and config-side groups are normalized
+- Normalization: TrimSpace, LDAP CN extraction, email domain stripping, lowercase
+
+## Adding fixtures
+
+1. Create a new JSON file following the naming convention: `NN_descriptive_name.json`
+2. Both butler-server and butler-controller tests consume all fixtures via `LoadAll()`
+3. Adding a fixture requires both consumer test suites to pass against it
+4. Removing or modifying an existing fixture is a breaking change for downstream tests
+
+## Consuming fixtures
+
+```go
+import "github.com/butlerdotdev/butler-api/testdata/resolution"
+
+func TestResolutionDrift(t *testing.T) {
+    for _, fixture := range resolution.LoadAll() {
+        t.Run(fixture.Name, func(t *testing.T) {
+            // Map fixture inputs to your domain types, call your
+            // resolution function, sort the output by team name,
+            // compare against fixture.Expected.
+        })
+    }
+}
+```
+
+## Consumer tests must sort output
+
+The expected output in each fixture is sorted by team name ascending.
+Consumer tests must sort their resolution function's output before
+comparing against the fixture expectations. This ensures the fixtures
+test resolution correctness, not implementation-specific iteration order.

--- a/testdata/resolution/loader.go
+++ b/testdata/resolution/loader.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resolution provides shared test fixtures for the User-Team
+// membership resolution contract. Both butler-server and butler-controller
+// implement the resolution logic independently (Factor-1 decision). These
+// fixtures encode the expected behavior: same inputs must produce identical
+// outputs from both implementations.
+//
+// Consumer tests import this package, call LoadAll(), and assert their
+// resolution function produces output matching each fixture's Expected
+// slice. Drift between implementations surfaces as a test failure in
+// whichever component diverged.
+//
+// Expected output is sorted by team name ascending. Consumer tests must
+// sort their resolution output before comparing against fixtures.
+package resolution
+
+import (
+	"embed"
+	"encoding/json"
+	"path/filepath"
+	"sort"
+)
+
+//go:embed *.json
+var fixtureFS embed.FS
+
+// FixtureTeamUser represents a user entry in a Team's access configuration.
+type FixtureTeamUser struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+// FixtureTeamGroup represents a group entry in a Team's access configuration.
+type FixtureTeamGroup struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+// FixtureTeamAccess represents the access configuration of a Team.
+type FixtureTeamAccess struct {
+	Users  []FixtureTeamUser  `json:"users"`
+	Groups []FixtureTeamGroup `json:"groups"`
+}
+
+// FixtureTeam represents a Team CRD with only the fields relevant to
+// resolution: name and access configuration.
+type FixtureTeam struct {
+	Name   string            `json:"name"`
+	Access FixtureTeamAccess `json:"access"`
+}
+
+// FixtureInput contains the inputs to the resolution function.
+type FixtureInput struct {
+	Email          string        `json:"email"`
+	LastSeenGroups []string      `json:"lastSeenGroups"`
+	Teams          []FixtureTeam `json:"teams"`
+}
+
+// ExpectedMembership represents a single team membership in the expected
+// output. Matches the shape of UserTeamMembership in the API types.
+type ExpectedMembership struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+// Fixture represents a single test case with inputs and expected output.
+type Fixture struct {
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Input       FixtureInput         `json:"input"`
+	Expected    []ExpectedMembership `json:"expected"`
+}
+
+// LoadAll reads all fixture JSON files from the embedded testdata and
+// returns them sorted by fixture name. Panics on malformed fixtures
+// (intended for test-time use, not runtime).
+func LoadAll() []Fixture {
+	entries, err := fixtureFS.ReadDir(".")
+	if err != nil {
+		panic("resolution fixtures: reading directory: " + err.Error())
+	}
+
+	var fixtures []Fixture
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		data, err := fixtureFS.ReadFile(entry.Name())
+		if err != nil {
+			panic("resolution fixtures: reading " + entry.Name() + ": " + err.Error())
+		}
+
+		var f Fixture
+		if err := json.Unmarshal(data, &f); err != nil {
+			panic("resolution fixtures: parsing " + entry.Name() + ": " + err.Error())
+		}
+
+		if f.Name == "" {
+			panic("resolution fixtures: " + entry.Name() + " has empty name")
+		}
+
+		fixtures = append(fixtures, f)
+	}
+
+	sort.Slice(fixtures, func(i, j int) bool {
+		return fixtures[i].Name < fixtures[j].Name
+	})
+
+	return fixtures
+}


### PR DESCRIPTION
## Summary

- Add 13 shared test fixtures in `testdata/resolution/` for User-Team membership resolution
- Add `LoadAll()` loader using `embed.FS` for consumer import
- Fixtures encode the resolution contract so butler-server and butler-controller drift is detected by CI

## Context

The User-Team membership resolution arc uses two independent implementations (Factor-1 decision): butler-server resolves at request time via unstructured client, butler-controller resolves via typed CRD objects. Both must produce identical output for the same inputs.

These fixtures are the drift protection mechanism. Each consumer imports the fixtures and asserts its resolution function produces the expected output. Divergence surfaces as a test failure.

## Fixture coverage

| Case | Tests |
|------|-------|
| `empty_no_access` | No groups, no manual access |
| `manual_only` | Manual access without SSO groups |
| `groups_no_match` | Groups present, no matching team |
| `group_single_team` | UUID group matches one team |
| `group_multiple_teams` | Groups match three teams, sorted output |
| `manual_and_group_highest_role` | Group admin beats manual viewer |
| `manual_and_group_manual_higher` | Manual admin beats group viewer |
| `group_normalization_uuid` | Case-insensitive UUID matching |
| `group_normalization_email` | Email domain stripping |
| `group_normalization_ldap` | LDAP CN extraction |
| `sort_determinism` | Five teams in reverse order |
| `default_role` | Empty role defaults to viewer |
| `empty_lastseengroups_explicit` | Empty slice vs nil distinction |

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- Loader parses all 13 fixtures correctly (verified via standalone test program)